### PR TITLE
Added Roter Balancing for Session and NoSession Actions

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -3,4 +3,30 @@ app {
 }
 akka {
   loglevel = "INFO"
+
+  actor {
+    guardian-supervisor-strategy = "akka.actor.DefaultSupervisorStrategy"
+    deployment {
+      /sessionrouter {
+        router = consistent-hashing-pool
+        nr-of-instances = 5
+        virtual-nodes-factor = 10
+      }
+      /nosessionrouter {
+        router = round-robin-pool
+        resizer {
+          enabled = on
+          lower-bound = 1
+          upper-bound = 50
+          pressure-threshold = 1
+          rampup-rate = 0.25
+          backoff-threshold = 0.25
+          backoff-rate = 0.25
+          messages-per-resize = 200
+        }
+        nr-of-instances = 3
+      }
+    }
+  }
+
 }

--- a/src/main/scala/com/bankbot/Main.scala
+++ b/src/main/scala/com/bankbot/Main.scala
@@ -1,8 +1,9 @@
 package com.bankbot
 
 import akka.actor.{ActorRef, ActorSystem}
+import akka.routing.FromConfig
 import com.bankbot.telegram.TelegramApiImpl
-import com.bankbot.tinkoff.{TinkoffApi, TinkoffApiImpl}
+import com.bankbot.tinkoff.TinkoffApiImpl
 import com.typesafe.config.ConfigFactory
 
 /**
@@ -14,8 +15,21 @@ object Main extends App {
 
   val tinkoffApi = new TinkoffApiImpl
   val telegramApi = new TelegramApiImpl
-  val noSessionActions: ActorRef = system.actorOf(
-    NoSessionActions.props(system.scheduler, conf.getInt("app.updateRatesInterval"), telegramApi, tinkoffApi))
-  val sessionManager = system.actorOf(SessionManager.props(telegramApi, tinkoffApi))
-  val getUpdates = system.actorOf(TelegramUpdater.props(sessionManager, noSessionActions, telegramApi))
+//  val noSessionActions: ActorRef = system.actorOf(
+//    NoSessionActions.props(system.scheduler, conf.getInt("app.updateRatesInterval"), telegramApi, tinkoffApi))
+//  val sessionManager = system.actorOf(SessionManager.props(telegramApi, tinkoffApi))
+  val noSessionRouter = system.actorOf(
+    FromConfig.props(NoSessionActions.props(
+      system.scheduler,
+      conf.getInt("app.updateRatesInterval"),
+      telegramApi,
+      tinkoffApi)),
+      "nosessionrouter"
+  )
+  val sessionRouter = system.actorOf(
+    FromConfig.props(SessionManager.props(telegramApi, tinkoffApi)),
+    "sessionrouter"
+  )
+
+  val getUpdates = system.actorOf(TelegramUpdater.props(sessionRouter, noSessionRouter, telegramApi))
 }

--- a/src/main/scala/com/bankbot/SessionManager.scala
+++ b/src/main/scala/com/bankbot/SessionManager.scala
@@ -2,6 +2,7 @@ package com.bankbot
 
 import akka.actor.{Actor, ActorLogging, ActorRef, Props, Terminated}
 import akka.event.LoggingAdapter
+import akka.routing.ConsistentHashingRouter.ConsistentHashable
 import com.bankbot.UserSession.Reply
 import com.bankbot.tinkoff.TinkoffApi
 import telegram.TelegramTypes._
@@ -17,8 +18,13 @@ object SessionManager {
   def props(telegramApi: TelegramApi, tinkoffApi: TinkoffApi) =
     Props(classOf[SessionManager], telegramApi, tinkoffApi)
 
-  case class PossibleContact(chatId: Int, contact: Contact)
-  case class PossibleReply(chatId: Int, messageId: Int, text: String)
+  abstract class WithChatSession extends ConsistentHashable {
+    val chatId: Int
+    override def consistentHashKey: Any = chatId
+  }
+
+  case class PossibleContact(override val chatId: Int, contact: Contact) extends WithChatSession
+  case class PossibleReply( override val chatId: Int, messageId: Int, text: String) extends WithChatSession
   case class WaitForReply(chatId: Int, messageId: Int)
 }
 

--- a/src/main/scala/com/bankbot/TelegramUpdater.scala
+++ b/src/main/scala/com/bankbot/TelegramUpdater.scala
@@ -2,7 +2,6 @@ package com.bankbot
 
 import akka.actor.{Actor, ActorLogging, ActorRef, Props}
 import akka.event.LoggingAdapter
-import com.bankbot.SessionManager.PossibleReply
 import com.bankbot.telegram.TelegramApi
 import com.bankbot.telegram.PrettyMessage.{prettyHelp, prettyNonPrivate}
 import telegram.TelegramTypes.{Message, ServerAnswer}
@@ -66,7 +65,7 @@ class TelegramUpdater(sessionManager: ActorRef, noSessionActions: ActorRef,
               sessionManager ! SessionManager.PossibleContact(update.message.chat.id, contact)
             }
             case Message(message_id, Some(user), chat, _, Some(reply), Some(text), None) => {
-              sessionManager ! PossibleReply(chat.id, reply.message_id, text)
+              sessionManager ! SessionManager.PossibleReply(chat.id, reply.message_id, text)
             }
           }
         } else {

--- a/src/main/scala/com/bankbot/UserSession.scala
+++ b/src/main/scala/com/bankbot/UserSession.scala
@@ -7,7 +7,7 @@ import com.bankbot.telegram.TelegramApi
 import com.bankbot.tinkoff.TinkoffApi
 import com.bankbot.telegram.TelegramTypes._
 import com.bankbot.tinkoff.TinkoffTypes._
-import com.bankbot.SessionManager.WaitForReply
+import com.bankbot.SessionManager.{WaitForReply, WithChatSession}
 import telegram.PrettyMessage._
 
 import scala.concurrent.duration._
@@ -23,9 +23,8 @@ object UserSession {
             tinkoffApi: TinkoffApi, scheduler: Scheduler) = Props(
     classOf[UserSession], chatId, contact, initialCommand, telegramApi, tinkoffApi, scheduler
   )
-  abstract class SessionCommand {
+  abstract class SessionCommand extends WithChatSession {
     val from: User
-    val chatId: Int
   }
   case class BalanceCommand(override val from: User, override val chatId: Int) extends SessionCommand
   case class HistoryCommand(override val from: User, override val chatId: Int) extends SessionCommand


### PR DESCRIPTION
Using consistent-hashing-pool for NoSessionActions
All messages for NoSessionManager are inherited from WithChatSession, that defines consistentHashKey as chatId.

Using round-robin-pool with resizer for NoSessionActions 
