### PR TITLE
Added Cluster mode, Logging and Deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ target
 **/project/project/target
 #telegram key
 src/main/resources/telegram.conf
+src/main/scala/Test.scala
+src/main/scala/com/bankbot/ClusterListner.scala
 
 # WorkSheet files
 *.sc

--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@ target
 #telegram key
 src/main/resources/telegram.conf
 src/main/scala/Test.scala
-src/main/scala/com/bankbot/ClusterListner.scala
 
 # WorkSheet files
 *.sc

--- a/README.md
+++ b/README.md
@@ -13,4 +13,35 @@ Created by pakondratyuk and VecnaSecrets
 - /history or /h - to get last operations
 - /help or /h - for help
 
+# Build
+sbt assembly    - produces fat tinkoff-bot.jar
+
+# Run Singleton mode
+java -jar tinkoff-bot.jar
+
+# Run Cluster mode
+Requires:
+    at least 1 master node and 2 worker nodes
+    seed nodes are configured on 127.0.0.1:2551 - 2553
+About:
+    TelegramUpdater - is singleton Actor running on master nodes
+    SessionManager and NoSessionActions are deployed on worker nodes by Router Pools
+
+How to:
+Start Master:
+    java -jar tinkoff-bot.jar master    (by-default start on 127.0.0.1:2551)
+
+Start Workers:
+    java -jar tinkoff-bot.jar worker       starts on 127.0.0.1 and random port
+    java -jar tinkoff-bot.jar worker       starts on 127.0.0.1 and random port
+
+# Additional config
+You can control host, port, seed params through Java System Properties
+Example:
+    java -jar -DHOST=host1 -DPORT=5551 tinkoff-bot.jar master
+    java -jar -Dakka.cluster.seed-nodes.0=akka.tcp://botsystem@host1:5551 tinkoff-bot.jar worker
+
+
+
+
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,13 +4,26 @@ version := "1.0"
 
 scalaVersion := "2.11.8"
 
-scalacOptions += "-feature"
-scalacOptions += "-language:postfixOps"
+scalacOptions ++= Seq(
+  "-deprecation",
+  "-unchecked",
+  "-Xfatal-warnings",
+  "-Ywarn-unused",
+  "-Ywarn-dead-code",
+  "-feature",
+  "-language:postfixOps"
+)
+
+//enablePlugins(JavaAppPackaging)
+//mainClass in Compile := Some("com.bankbot.Main")
+//
+//scriptClasspath +="../conf"
 
 libraryDependencies ++= {
   val akkaVersion = "2.4.17"
   Seq(
     "com.typesafe.akka" %% "akka-actor"               % akkaVersion,
+    "com.typesafe.akka" %% "akka-cluster"             % akkaVersion,
     "com.typesafe.akka" %% "akka-stream"              % akkaVersion,
     "com.typesafe.akka" %% "akka-slf4j"               % akkaVersion,
     "com.typesafe.akka" %% "akka-testkit"             % akkaVersion,
@@ -20,6 +33,11 @@ libraryDependencies ++= {
     "com.typesafe.akka" %% "akka-http-testkit"        % "10.0.4",
     "org.scalatest"     %  "scalatest_2.11"           % "3.0.1",
     "org.mockito"       %  "mockito-all"              % "1.9.5",
+    "ch.qos.logback"    %  "logback-classic"          % "1.1.3",
     "com.miguno.akka"   %  "akka-mock-scheduler_2.11" % "0.5.1"
   )
 }
+
+// Assembly settings
+mainClass in assembly := Some("com.bankbot.Main")
+assemblyJarName in assembly := "tinkoff-bot.jar"

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,9 @@ libraryDependencies ++= {
   val akkaVersion = "2.4.17"
   Seq(
     "com.typesafe.akka" %% "akka-actor"               % akkaVersion,
+    "com.typesafe.akka" %% "akka-remote"              % akkaVersion,
     "com.typesafe.akka" %% "akka-cluster"             % akkaVersion,
+    "com.typesafe.akka" %% "akka-cluster-tools"       % akkaVersion,
     "com.typesafe.akka" %% "akka-stream"              % akkaVersion,
     "com.typesafe.akka" %% "akka-slf4j"               % akkaVersion,
     "com.typesafe.akka" %% "akka-testkit"             % akkaVersion,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,6 @@
+resolvers += Classpaths.typesafeReleases
+
 logLevel := Level.Warn
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.0.0-RC1")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.5")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.0")

--- a/src/main/resources/ExampleGetUpdate
+++ b/src/main/resources/ExampleGetUpdate
@@ -1,4 +1,0 @@
-{"ok":true,"result":[]}
-
-{"ok":true,"result":[{"update_id":20563606,
-"message":{"message_id":8,"from":{"id":151656477,"first_name":"\u041f\u0430\u0432\u0435\u043b","last_name":"\u041a\u043e\u043d\u0434\u0440\u0430\u0442\u044e\u043a","username":"Fity511"},"chat":{"id":151656477,"first_name":"\u041f\u0430\u0432\u0435\u043b","last_name":"\u041a\u043e\u043d\u0434\u0440\u0430\u0442\u044e\u043a","username":"Fity511","type":"private"},"date":1489830884,"text":"/test","entities":[{"type":"bot_command","offset":0,"length":5}]}}]}

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -3,6 +3,38 @@ app {
   updateRatesInterval = 2000
 }
 akka {
+  loggers = ["akka.event.slf4j.Slf4jLogger"]
+  logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
   #ERROR,WARNING,INFO,DEBUG
-  loglevel = "INFO"
+  stdout-loglevel = "DEBUG"
+  log-config-on-start = off
+
+  actor {
+    debug {
+      # enable DEBUG logging of actor lifecycle changes
+      lifecycle = on
+    }
+    guardian-supervisor-strategy = "akka.actor.DefaultSupervisorStrategy"
+    deployment {
+      /sessionrouter {
+        router = consistent-hashing-pool
+        nr-of-instances = 5
+        virtual-nodes-factor = 10
+      }
+      /nosessionrouter {
+        router = round-robin-pool
+        resizer {
+          enabled = on
+          lower-bound = 1
+          upper-bound = 50
+          pressure-threshold = 1
+          rampup-rate = 0.25
+          backoff-threshold = 0.25
+          backoff-rate = 0.25
+          messages-per-resize = 200
+        }
+        nr-of-instances = 3
+      }
+    }
+  }
 }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,32 +1,8 @@
 app {
+  #milliseconds
   updateRatesInterval = 2000
 }
 akka {
+  #ERROR,WARNING,INFO,DEBUG
   loglevel = "INFO"
-
-  actor {
-    guardian-supervisor-strategy = "akka.actor.DefaultSupervisorStrategy"
-    deployment {
-      /sessionrouter {
-        router = consistent-hashing-pool
-        nr-of-instances = 5
-        virtual-nodes-factor = 10
-      }
-      /nosessionrouter {
-        router = round-robin-pool
-        resizer {
-          enabled = on
-          lower-bound = 1
-          upper-bound = 50
-          pressure-threshold = 1
-          rampup-rate = 0.25
-          backoff-threshold = 0.25
-          backoff-rate = 0.25
-          messages-per-resize = 200
-        }
-        nr-of-instances = 3
-      }
-    }
-  }
-
 }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -5,8 +5,9 @@ app {
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
+  loglevel = "INFO"
   #ERROR,WARNING,INFO,DEBUG
-  stdout-loglevel = "DEBUG"
+  stdout-loglevel = "INFO"
   log-config-on-start = off
 
   actor {

--- a/src/main/resources/cluster_main.conf
+++ b/src/main/resources/cluster_main.conf
@@ -6,16 +6,15 @@ akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
   #ERROR,WARNING,INFO,DEBUG
-  stdout-loglevel = "DEBUG"
+  #loglevel = "INFO"
+  #stdout-loglevel = "INFO"
   log-config-on-start = off
 
   actor {
+    provider = "akka.cluster.ClusterActorRefProvider"
     guardian-supervisor-strategy = "akka.actor.DefaultSupervisorStrategy"
-
-    debug {
-      # enable DEBUG logging of actor lifecycle changes
-      lifecycle = on
-    }
+    #serialize-creators = on
+    warn-about-java-serializer-usage = off
 
     deployment {
 
@@ -24,11 +23,11 @@ akka {
         nr-of-instances = 5
         virtual-nodes-factor = 10
 
-        resizer {
+        cluster {
           enabled = on
-          lower-bound = 2
-          upper-bound = 10
-          messages-per-resize = 100
+          allow-local-routees = off
+          maxInstancesPerNode = 1
+          use-role = worker
         }
       }
 
@@ -37,19 +36,9 @@ akka {
 
         cluster {
           enabled = on
-          allow-local-routees = on
+          allow-local-routees = off
           maxInstancesPerNode = 1
-        }
-
-        resizer {
-          enabled = on
-          lower-bound = 2
-          upper-bound = 10
-          pressure-threshold = 1
-          rampup-rate = 0.25
-          backoff-threshold = 0.25
-          backoff-rate = 0.25
-          messages-per-resize = 200
+          use-role = worker
         }
       }
 
@@ -59,11 +48,12 @@ akka {
 
   remote {
     enabled-transports = ["akka.remote.netty.tcp"]
-    log-remote-lifecycle-events = off
+    log-remote-lifecycle-events = on
     netty.tcp {
       hostname = "127.0.0.1"
       hostname = ${?HOST}
-      port = ${PORT}
+      port = 2551
+      port = ${?PORT}
     }
   }
 
@@ -74,12 +64,16 @@ akka {
       "akka.tcp://botsystem@127.0.0.1:2553"
     ]
     roles = ["master"]
-    auto-down = on
+    auto-down-unreachable-after = 15s
+    auto-down = off
 
     role {
-      seed.min-nr-of-members = 1
       master.min-nr-of-members = 1
       worker.min-nr-of-members = 2
+    }
+
+    singleton {
+      hand-over-retry-interval = 1s
     }
   }
 }

--- a/src/main/resources/cluster_main.conf
+++ b/src/main/resources/cluster_main.conf
@@ -10,16 +10,20 @@ akka {
   log-config-on-start = off
 
   actor {
+    guardian-supervisor-strategy = "akka.actor.DefaultSupervisorStrategy"
+
     debug {
       # enable DEBUG logging of actor lifecycle changes
       lifecycle = on
     }
-    guardian-supervisor-strategy = "akka.actor.DefaultSupervisorStrategy"
+
     deployment {
+
       /sessionrouter {
         router = consistent-hashing-pool
         nr-of-instances = 5
         virtual-nodes-factor = 10
+
         resizer {
           enabled = on
           lower-bound = 2
@@ -27,8 +31,16 @@ akka {
           messages-per-resize = 100
         }
       }
+
       /nosessionrouter {
         router = round-robin-pool
+
+        cluster {
+          enabled = on
+          allow-local-routees = on
+          maxInstancesPerNode = 1
+        }
+
         resizer {
           enabled = on
           lower-bound = 2
@@ -40,6 +52,34 @@ akka {
           messages-per-resize = 200
         }
       }
+
+    }
+
+  }
+
+  remote {
+    enabled-transports = ["akka.remote.netty.tcp"]
+    log-remote-lifecycle-events = off
+    netty.tcp {
+      hostname = "127.0.0.1"
+      hostname = ${?HOST}
+      port = ${PORT}
+    }
+  }
+
+  cluster {
+    seed-nodes = [
+      "akka.tcp://botsystem@127.0.0.1:2551",
+      "akka.tcp://botsystem@127.0.0.1:2552",
+      "akka.tcp://botsystem@127.0.0.1:2553"
+    ]
+    roles = ["master"]
+    auto-down = on
+
+    role {
+      seed.min-nr-of-members = 1
+      master.min-nr-of-members = 1
+      worker.min-nr-of-members = 2
     }
   }
 }

--- a/src/main/resources/cluster_worker.conf
+++ b/src/main/resources/cluster_worker.conf
@@ -1,0 +1,46 @@
+akka {
+  loggers = ["akka.event.slf4j.Slf4jLogger"]
+  logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
+  #ERROR,WARNING,INFO,DEBUG
+  stdout-loglevel = "DEBUG"
+  log-config-on-start = off
+
+  actor {
+    guardian-supervisor-strategy = "akka.actor.DefaultSupervisorStrategy"
+    serialize-creators = on
+    warn-about-java-serializer-usage = off
+
+    provider = "akka.cluster.ClusterActorRefProvider"
+
+    debug {
+      # enable DEBUG logging of actor lifecycle changes
+      lifecycle = on
+    }
+
+  }
+
+  remote {
+    enabled-transports = ["akka.remote.netty.tcp"]
+    log-remote-lifecycle-events = off
+    netty.tcp {
+      hostname = "127.0.0.1"
+      hostname = ${?HOST}
+      port = 0
+    }
+  }
+
+  cluster {
+    seed-nodes = [
+      "akka.tcp://botsystem@127.0.0.1:2551",
+      "akka.tcp://botsystem@127.0.0.1:2552",
+      "akka.tcp://botsystem@127.0.0.1:2553"
+    ]
+    roles = ["worker"]
+    auto-down = on
+
+    role {
+      master.min-nr-of-members = 1
+      worker.min-nr-of-members = 2
+    }
+  }
+}

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,20 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} TKD [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <file>tinkoff-bot.log</file>
+        <append>true</append>
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} TKD [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="debug">
+        <!--<appender-ref ref="STDOUT" />-->
+        <appender-ref ref="FILE" />
+    </root>
+</configuration>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -14,7 +14,7 @@
     </appender>
 
     <root level="debug">
-        <!--<appender-ref ref="STDOUT" />-->
+        <appender-ref ref="STDOUT" />
         <appender-ref ref="FILE" />
     </root>
 </configuration>

--- a/src/main/scala/com/bankbot/ClusterListner.scala
+++ b/src/main/scala/com/bankbot/ClusterListner.scala
@@ -1,0 +1,58 @@
+package com.bankbot
+
+import akka.actor.{Actor, ActorLogging, ActorRef}
+import akka.cluster.{Cluster, Member, MemberStatus}
+import akka.cluster.ClusterEvent._
+import com.bankbot.ClusterDomainEventListener.ControlUpdater
+import com.bankbot.TelegramUpdater.{StartProcessing, StopProcessing}
+
+/**
+  * Actor that is responsible for cluster events handling
+  */
+object ClusterDomainEventListener {
+  case class ControlUpdater(telegramUpdater: ActorRef)
+}
+
+class ClusterDomainEventListener extends Actor with ActorLogging {
+  Cluster(context.system).subscribe(self, classOf[ClusterDomainEvent])
+  var updater: Option[ActorRef] = None
+  var upWorkers = Set[Member]()
+
+  def receive = {
+    case MemberJoined(member) =>
+      log.info(s"$member JOINED.")
+    case MemberUp(member) => {
+      log.info(s"$member UP.")
+      if (member.roles.contains("worker")) {
+        upWorkers = upWorkers + member
+        if(upWorkers.size == 2) updater foreach(_ ! StartProcessing)
+      }
+    }
+    case MemberExited(member) =>
+      log.info(s"$member EXITED.")
+    case MemberRemoved(member, previousState) =>
+      if (previousState == MemberStatus.Exiting) {
+        log.info(s"Member $member Previously gracefully exited, REMOVED.")
+      } else {
+        log.info(s"$member Previously downed after unreachable, REMOVED.")
+      }
+    case UnreachableMember(member) => {
+      log.info(s"$member UNREACHABLE")
+      if (member.roles.contains("worker")) {
+        upWorkers = upWorkers - member
+        if(upWorkers.size ==  1) updater foreach(_ ! StopProcessing)
+      }
+    }
+    case ReachableMember(member) => {
+      log.info(s"$member REACHABLE")
+      if (member.roles.contains("worker")) {
+        upWorkers = upWorkers + member
+        if(upWorkers.size ==  2) updater foreach(_ ! StartProcessing)
+      }
+    }
+    case state: CurrentClusterState =>
+      log.info(s"Current state of the cluster: $state")
+
+    case ControlUpdater(telegramUpdater) => updater = Some(telegramUpdater)
+  }
+}

--- a/src/main/scala/com/bankbot/ClusterListner.scala
+++ b/src/main/scala/com/bankbot/ClusterListner.scala
@@ -50,8 +50,12 @@ class ClusterDomainEventListener extends Actor with ActorLogging {
         if(upWorkers.size ==  2) updater foreach(_ ! StartProcessing)
       }
     }
-    case state: CurrentClusterState =>
+    case state: CurrentClusterState => {
       log.info(s"Current state of the cluster: $state")
+      upWorkers = upWorkers ++ state.members.filter(m =>
+        m.roles.contains("worker") && m.status == MemberStatus.up
+      )
+    }
 
     case ControlUpdater(telegramUpdater) => updater = Some(telegramUpdater)
   }

--- a/src/main/scala/com/bankbot/Main.scala
+++ b/src/main/scala/com/bankbot/Main.scala
@@ -1,35 +1,118 @@
 package com.bankbot
 
-import akka.actor.{ActorRef, ActorSystem}
+import akka.actor.{ActorSystem, PoisonPill, Props}
+import akka.cluster.{Cluster, MemberStatus}
+import akka.cluster.singleton.{ClusterSingletonManager, ClusterSingletonManagerSettings, ClusterSingletonProxy, ClusterSingletonProxySettings}
+import akka.event.Logging
 import akka.routing.FromConfig
+import com.bankbot.ClusterDomainEventListener.ControlUpdater
+import com.bankbot.TelegramUpdater.{StartProcessing, StopProcessing}
 import com.bankbot.telegram.TelegramApiImpl
-import com.bankbot.tinkoff.TinkoffApiImpl
 import com.typesafe.config.ConfigFactory
 
 /**
   * Main class
   */
 object Main extends App {
-  val conf = ConfigFactory.load()
-  implicit val system = ActorSystem("BotSystem")
 
-  val tinkoffApi = new TinkoffApiImpl
-  val telegramApi = new TelegramApiImpl
-//  val noSessionActions: ActorRef = system.actorOf(
-//    NoSessionActions.props(system.scheduler, conf.getInt("app.updateRatesInterval"), telegramApi, tinkoffApi))
-//  val sessionManager = system.actorOf(SessionManager.props(telegramApi, tinkoffApi))
-  val noSessionRouter = system.actorOf(
-    FromConfig.props(NoSessionActions.props(
-      system.scheduler,
-      conf.getInt("app.updateRatesInterval"),
-      telegramApi,
-      tinkoffApi)),
+  if(args.isEmpty)
+    startSingletone()
+  else
+    args(0) match {
+      case "master" => startMaster()
+      case "worker" => startWorker()
+    }
+
+  def startSingletone() = {
+    val conf = ConfigFactory.load()
+    implicit val system = ActorSystem("BotSystem")
+
+    val telegramApi = new TelegramApiImpl
+    val noSessionRouter = system.actorOf(
+      FromConfig.props(NoSessionActions.props(
+        conf.getInt("app.updateRatesInterval"))),
       "nosessionrouter"
-  )
-  val sessionRouter = system.actorOf(
-    FromConfig.props(SessionManager.props(telegramApi, tinkoffApi)),
-    "sessionrouter"
-  )
+    )
+    val sessionRouter = system.actorOf(
+      FromConfig.props(SessionManager.props()),
+      "sessionrouter"
+    )
 
-  val getUpdates = system.actorOf(TelegramUpdater.props(sessionRouter, noSessionRouter, telegramApi))
+    val getUpdates = system.actorOf(TelegramUpdater.props(sessionRouter, noSessionRouter, telegramApi))
+    getUpdates ! StartProcessing
+  }
+
+  def startWorker() = {
+    val conf = ConfigFactory.load("cluster_worker")
+    implicit val system = ActorSystem("botsystem", conf)
+
+    println(s"Starting node with roles: ${Cluster(system).selfRoles}")
+  }
+
+  def startMaster() = {
+    val conf = ConfigFactory.load("cluster_main")
+    implicit val system = ActorSystem("botsystem", conf)
+    val log = Logging.getLogger(system, this)
+
+    log.info(s"Starting node with roles: ${Cluster(system).selfRoles}, waiting for 2 worker nodes!")
+
+
+    val noSessionRouter = system.actorOf(
+      FromConfig.props(NoSessionActions.props(
+        conf.getInt("app.updateRatesInterval"))),
+      "nosessionrouter"
+    )
+    val sessionRouter = system.actorOf(
+      FromConfig.props(SessionManager.props()),
+      "sessionrouter"
+    )
+
+    val telegramApi = new TelegramApiImpl
+
+    val updaterProps = Props(new TelegramUpdater(sessionRouter, noSessionRouter, telegramApi) {
+      override def preStart(): Unit = {
+        val numberOfworkers = Cluster(context.system).state.members.foldLeft(0)((acc, m)=>
+          if(m.roles.contains("worker") && m.status == MemberStatus.up)
+            acc+1
+          else
+            acc
+        )
+        if(numberOfworkers >= 2)
+          self ! StartProcessing
+      }
+    })
+
+    val singletonManager = system.actorOf(
+      ClusterSingletonManager.props(
+        updaterProps,
+        PoisonPill,
+        ClusterSingletonManagerSettings(system)
+          .withRole("master")
+          .withSingletonName(TelegramUpdater.name)
+      )
+    )
+
+    val telegramUpdater = system.actorOf(
+      ClusterSingletonProxy.props(
+        singletonManager.path.child(TelegramUpdater.name)
+          .toStringWithoutAddress,
+        ClusterSingletonProxySettings(system)
+          .withRole("master")
+          .withSingletonName("updater-proxy"))
+    )
+
+    val clusterListener = system.actorOf(Props[ClusterDomainEventListener], "clusterListener")
+    clusterListener ! ControlUpdater(telegramUpdater)
+
+    val cluster = Cluster(system)
+    cluster.registerOnMemberUp {
+      log.info("Woker NodesBot Functionality Starts!")
+      telegramUpdater ! StartProcessing
+    }
+
+    cluster.registerOnMemberRemoved {
+      log.info("Bot Functionality Stops, Waiting for 2 worker nodes!")
+      telegramUpdater ! StopProcessing
+    }
+  }
 }

--- a/src/main/scala/com/bankbot/Main.scala
+++ b/src/main/scala/com/bankbot/Main.scala
@@ -2,7 +2,7 @@ package com.bankbot
 
 import akka.actor.{ActorRef, ActorSystem}
 import com.bankbot.telegram.TelegramApiImpl
-import com.bankbot.tinkoff.{TinkoffApi, TinkoffApiImpl}
+import com.bankbot.tinkoff.TinkoffApiImpl
 import com.typesafe.config.ConfigFactory
 
 /**

--- a/src/main/scala/com/bankbot/SessionManager.scala
+++ b/src/main/scala/com/bankbot/SessionManager.scala
@@ -18,7 +18,7 @@ object SessionManager {
   def props(telegramApi: TelegramApi, tinkoffApi: TinkoffApi) =
     Props(classOf[SessionManager], telegramApi, tinkoffApi)
 
-  abstract class WithChatSession extends ConsistentHashable {
+  trait WithChatSession extends ConsistentHashable {
     val chatId: Int
     override def consistentHashKey: Any = chatId
   }

--- a/src/main/scala/com/bankbot/SessionManager.scala
+++ b/src/main/scala/com/bankbot/SessionManager.scala
@@ -66,6 +66,11 @@ class SessionManager(telegramApi: TelegramApi,
       telegramApi.sendMessage(message)
     }
 
+    case Terminated(actor)=> {
+      val remove = awatingReply.filter(pair => pair._1 == actor.path.name)
+      awatingReply = awatingReply -- remove
+    }
+
   }
 
   def createUserSession(name: String, command: SessionCommand): ActorRef = {

--- a/src/main/scala/com/bankbot/TelegramUpdater.scala
+++ b/src/main/scala/com/bankbot/TelegramUpdater.scala
@@ -1,6 +1,7 @@
 package com.bankbot
 
 import akka.actor.{Actor, ActorLogging, ActorRef, Props}
+import akka.cluster.{Cluster, Member, MemberStatus}
 import akka.event.LoggingAdapter
 import com.bankbot.telegram.TelegramApi
 import com.bankbot.telegram.PrettyMessage.{prettyHelp, prettyNonPrivate}
@@ -13,8 +14,11 @@ import telegram.TelegramTypes.{Message, ServerAnswer}
 object TelegramUpdater {
   def props(sessionManager: ActorRef, noSessionActions: ActorRef, telegramApi: TelegramApi) =
     Props(classOf[TelegramUpdater], sessionManager, noSessionActions, telegramApi)
+  val name = "telegram-updater"
   case object getOffset
   case class Offset(offset: Int)
+  case object StartProcessing
+  case object StopProcessing
 }
 
 class TelegramUpdater(sessionManager: ActorRef, noSessionActions: ActorRef,
@@ -23,10 +27,23 @@ class TelegramUpdater(sessionManager: ActorRef, noSessionActions: ActorRef,
   import TelegramUpdater._
   implicit val logger: LoggingAdapter = log
 
-  private var offset = 0
-  override def preStart(): Unit = telegramApi.getUpdates(offset)
+  log.info("TelegramUpdater created! " + context.self.path.toString)
 
-  def receive = {
+  private var offset = 0
+
+  def init: Receive = {
+    case StartProcessing => {
+      log.info("TelegramUpdater starts processing messages! " + context.self.path.toString)
+      context.become(work)
+      telegramApi.getUpdates(offset)
+    }
+  }
+
+  def work: Receive = {
+    case StopProcessing => {
+      log.info("TelegramUpdater stops processing messages! " + context.self.path.toString)
+      context.become(init)
+    }
     case ServerAnswer(true, result) => {
       for (update <- result) {
         if (update.message.chat.c_type == "private") {
@@ -70,5 +87,7 @@ class TelegramUpdater(sessionManager: ActorRef, noSessionActions: ActorRef,
     case ServerAnswer(false, _) => telegramApi.getUpdates(offset)
     case getOffset => sender ! Offset(offset)
   }
+
+  def receive = init
 
 }

--- a/src/main/scala/com/bankbot/TelegramUpdater.scala
+++ b/src/main/scala/com/bankbot/TelegramUpdater.scala
@@ -34,30 +34,22 @@ class TelegramUpdater(sessionManager: ActorRef, noSessionActions: ActorRef,
           update.message match {
             case Message(_, Some(user), chat, _, None, Some(text), None) => {
               text match {
-                // - Если кто-то пытается пользоваться без авторизации,
-                // - то ему придёт кнопка отправки контакта.
                 case s if s == "/rates" || s == "/r" => {
-                  // – для получения курсов
                   noSessionActions ! NoSessionActions.SendRates(chat.id)
                 }
                 case s if s == "/balance" || s == "/b" => {
-                  // – команды, которые требую аутентификации
                   sessionManager ! UserSession.BalanceCommand(user, chat.id)
                 }
                 case s if s == "/history" || s == "/hi" => {
-                  // – команды, которые требую аутентификации
                   sessionManager ! UserSession.HistoryCommand(user, chat.id)
                 }
                 case s if s == "/help" || s == "/h" => {
-                  // -  справочник доступных функций
                   noSessionActions ! NoSessionActions.SendMessage(chat.id, prettyHelp)
                 }
                 case s if s == "/start" || s == "/s" => {
-                  // -  сообщение при старте
                   noSessionActions ! NoSessionActions.SendMessage(chat.id, prettyHelp)
                 }
                 case s => {
-                  //            log.info("Got undefined command: " + s)
                   noSessionActions ! NoSessionActions.SendMessage(chat.id, "No Such Command\nSee /help")
                 }
               }

--- a/src/main/scala/com/bankbot/UserSession.scala
+++ b/src/main/scala/com/bankbot/UserSession.scala
@@ -23,7 +23,7 @@ object UserSession {
             tinkoffApi: TinkoffApi, scheduler: Scheduler) = Props(
     classOf[UserSession], chatId, contact, initialCommand, telegramApi, tinkoffApi, scheduler
   )
-  abstract class SessionCommand extends WithChatSession {
+  sealed trait SessionCommand extends WithChatSession {
     val from: User
   }
   case class BalanceCommand(override val from: User, override val chatId: Int) extends SessionCommand

--- a/src/main/scala/com/bankbot/telegram/TelegramApi.scala
+++ b/src/main/scala/com/bankbot/telegram/TelegramApi.scala
@@ -43,11 +43,11 @@ class TelegramApiImpl(implicit system: ActorSystem) extends TelegramApi with Mes
     val response = http.singleRequest(HttpRequest(uri = uri))
     (response flatMap {
       case HttpResponse(StatusCodes.OK, _, entity, _) => {
-        logger.debug("Telegram getUpdates Request Success")
+        //logger.debug("Telegram getUpdates Request Success")
         Unmarshal(entity).to[ServerAnswer]
       }
       case HttpResponse(code, _, entity, _) => {
-        logger.warning("Telegram getUpdates Request failed, response code: " + code)
+        //logger.warning("Telegram getUpdates Request failed, response code: " + code)
         throw ResponceCodeException("Telegram getUpdates Responce code:", entity)
       }
     } recover {

--- a/src/main/scala/com/bankbot/tinkoff/TinkoffApi.scala
+++ b/src/main/scala/com/bankbot/tinkoff/TinkoffApi.scala
@@ -139,7 +139,13 @@ class TinkoffApiImpl(implicit system: ActorSystem)
     (response flatMap {
       case HttpResponse(StatusCodes.OK, _, entity, _) => {
         logger.debug("Tinkoff confirm Request Success")
-        Unmarshal(entity).to[Confirm]      }
+        Unmarshal(entity).to[Confirm].recover {
+          case e => {
+            logger.info("SMS confirmation Unmarshalling failed")
+            Confirm("Unmarhal failure", Right(Confirmation("Empty")))
+          }
+        }
+      }
       case HttpResponse(code, _, entity, _) => {
         logger.warning("Tinkoff confirm Request failed, response code: " + code)
         throw ResponceCodeException("Tinkoff Responce code:", entity)

--- a/src/main/scala/com/bankbot/tinkoff/TinkoffTypes.scala
+++ b/src/main/scala/com/bankbot/tinkoff/TinkoffTypes.scala
@@ -25,7 +25,7 @@ object TinkoffTypes {
   case class ConfirmPayLoad(accessLevel: String, sessionid: String, sessionTimeout: Int, additionalAuth: AdditionalAuth,
                             userId: String)
 
-  case class Confirm(resultCode: String, payload: Option[ConfirmPayLoad])
+  case class Confirm(resultCode: String, payload: Either[ConfirmPayLoad, Confirmation])
 
   case class AccessLevel(accessLevel: String)
 
@@ -71,10 +71,10 @@ trait MessageMarshallingTinkoff extends DefaultJsonProtocol {
   implicit val signUpFormat = jsonFormat3(SignUp)
   implicit val additionalAuthFormat = jsonFormat3(AdditionalAuth)
   implicit val confirmPayLoadFormat = jsonFormat5(ConfirmPayLoad)
+  implicit val confirmationFormat = jsonFormat1(Confirmation)
   implicit val confirmFormat = jsonFormat2(Confirm)
   implicit val accessLevelFormat = jsonFormat1(AccessLevel)
   implicit val levelUpFormat = jsonFormat2(LevelUp)
-  implicit val confirmationFormat = jsonFormat1(Confirmation)
   implicit val warmUpFormat = jsonFormat1(WarmUp)
   implicit val sessionStatusPayLoadFormat = jsonFormat4(SessionStatusPayLoad)
   implicit val sessionStatusFormat = jsonFormat3(SessionStatus)

--- a/src/test/scala/com/bankbot/NoSessionActionsTest.scala
+++ b/src/test/scala/com/bankbot/NoSessionActionsTest.scala
@@ -2,7 +2,7 @@ package com.bankbot
 
 import java.time.{Instant, ZoneId}
 
-import akka.actor.{ActorContext, ActorRef, ActorSystem}
+import akka.actor.{ActorContext, ActorRef, ActorSystem, Props}
 import akka.event.LoggingAdapter
 import akka.testkit.{ImplicitSender, TestKit}
 import com.bankbot.NoSessionActions._
@@ -38,7 +38,8 @@ class NoSessionActionsTest extends TestKit(ActorSystem("testBotSystem"))
   val rateNew = Rate("", Currency(0, "USD"), Currency(0, "RUB"), 58.2f, 56.7f)
 
   val time = new VirtualTime
-  val noSessionActions = system.actorOf(NoSessionActions.props(time.scheduler, 2000, telegramApiTest, tinkoffApiTest))
+  val noSessionActions = system.actorOf(Props(classOf[NoSessionActions], Some(time.scheduler), 2000,
+    Some(telegramApiTest), Some(tinkoffApiTest)))
   time.advance(1 second)
 
   "NoSessionActions" must {

--- a/src/test/scala/com/bankbot/SessionManagerTest.scala
+++ b/src/test/scala/com/bankbot/SessionManagerTest.scala
@@ -38,7 +38,7 @@ class SessionManagerTest extends TestKit(ActorSystem("testBotSystem"))
 
   val testUserSession = TestProbe(testChat.id.toString)
   val sessionManager = system.actorOf(Props(
-    new SessionManager(telegramApiTest, tinkoffApiTest) {
+    new SessionManager(Some(telegramApiTest), Some(tinkoffApiTest)) {
       override def createUserSession(name: String, command: SessionCommand): ActorRef = testUserSession.ref
     }
   ))

--- a/src/test/scala/com/bankbot/TelegramUpdaterTest.scala
+++ b/src/test/scala/com/bankbot/TelegramUpdaterTest.scala
@@ -32,6 +32,7 @@ class TelegramUpdaterTest extends TestKit(ActorSystem("testBotSystem"))
   val telegramUpdaterTest = system.actorOf(
       TelegramUpdater.props(sessionManagerTest.ref, noSessionActionsTest.ref, telegramApiTest)
     )
+  telegramUpdaterTest ! StartProcessing
   val testChat = Chat(1, "private")
   val testUser = User(1, "Name", Some("LastName"), Some("Login"))
   val testMessage = Message(1, Some(testUser), testChat, 123, None, Some("/bla"), None)

--- a/src/test/scala/com/bankbot/UserSessionTest.scala
+++ b/src/test/scala/com/bankbot/UserSessionTest.scala
@@ -55,7 +55,7 @@ class UserSessionTest extends TestKit(ActorSystem("testBotSystem"))
 
     "call getSession on start" in {
       val (tinkoffApiTest, telegramApiTest, time, parent) = createFixture
-      val userSession = parent.childActorOf(
+      parent.childActorOf(
         UserSession.props(1, testContact, BalanceCommand(testUser, 1), telegramApiTest, tinkoffApiTest, time.scheduler)
       )
       eventually {


### PR DESCRIPTION
#10 

**Build**
sbt assembly    - produces fat tinkoff-bot.jar

**Run Singleton mode**
java -jar tinkoff-bot.jar

**Run Cluster mode**
Requires:
    at least 1 master node and 2 worker nodes
    seed nodes are configured on 127.0.0.1:2551 - 2553
About:
    TelegramUpdater - is singleton Actor running on master nodes
    SessionManager and NoSessionActions are deployed on worker nodes by ClusterRouterPools

**How to:**
Start Master:
    java -jar tinkoff-bot.jar master    (by-default start on 127.0.0.1:2551)

Start Workers:
    java -jar tinkoff-bot.jar worker       starts on 127.0.0.1 and random port
    java -jar tinkoff-bot.jar worker       starts on 127.0.0.1 and random port

Additional config
You can control host, port, seed params through Java System Properties
Example:
    java -jar -DHOST=host1 -DPORT=5551 tinkoff-bot.jar master
    java -jar -Dakka.cluster.seed-nodes.0=akka.tcp://botsystem@host1:5551 tinkoff-bot.jar worker


